### PR TITLE
Fix mobile label clarity and adjust moving label positions

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,12 @@
  .axis line, .axis path { stroke:black; }
  .grid line { stroke:#ccc; stroke-dasharray:2,2; }
  .curve { fill:none; stroke:steelblue; stroke-width:2; }
- .label { font-size:12px; }
- .indicator { font-size:14px; font-weight:bold; }
+  .label { font-size:12px; }
+  .indicator { font-size:14px; font-weight:bold; }
+  @media (max-width:600px), (orientation:portrait) {
+    .label { font-size:16px; }
+    .indicator { font-size:18px; }
+  }
 </style>
 </head>
 <body>

--- a/script.js
+++ b/script.js
@@ -131,14 +131,14 @@
     xValueText=document.createElementNS(ns,'text');
     xValueText.setAttribute('class','label');
     xValueText.setAttribute('text-anchor','middle');
-    xValueText.setAttribute('y',height-margin.bottom+15);
+    xValueText.setAttribute('y',height-margin.bottom-8);
     xValueText.setAttribute('visibility','hidden');
     svg.appendChild(xValueText);
 
     yValueText=document.createElementNS(ns,'text');
     yValueText.setAttribute('class','label');
-    yValueText.setAttribute('text-anchor','end');
-    yValueText.setAttribute('x',margin.left-8);
+    yValueText.setAttribute('text-anchor','start');
+    yValueText.setAttribute('x',margin.left+8);
     yValueText.setAttribute('visibility','hidden');
     svg.appendChild(yValueText);
   }


### PR DESCRIPTION
## Summary
- make labels bigger on mobile and portrait screens
- move dynamic labels to the opposite side of each axis so they don't overlap axis labels

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841a0574a74832db6aceae9fb290fdc